### PR TITLE
grep -r for ubuntu-latest needed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ main() {
   echo "propertyKey: $propertyKey"
   echo "propertyValue: $propertyValue"
 
-  if ! grep -R "^[#]*\s*${propertyKey}=.*" "$path" > /dev/null; then
+  if ! grep -r "^[#]*\s*${propertyKey}=.*" "$path" > /dev/null; then
     echo "APPENDING because '${propertyKey}' not found"
     cat >> "$path" <<EOF
 


### PR DESCRIPTION
**What is the problem?**
Property will always be appended, because script does not find existing property.

Error log:
```
grep: unrecognized option: R
path: config.properties
propertyKey: version
propertyValue: 1.0.3
BusyBox v1.31.1 () multi-call binary.
APPENDING because 'version' not found

Usage: grep [-HhnlLoqvsriwFE] [-m N] [-A/B/C N] PATTERN/-e PATTERN.../-f FILE [FILE]...

Search for PATTERN in FILEs (or stdin)
	-H	Add 'filename:' prefix
	-h	Do not add 'filename:' prefix
	-n	Add 'line_no:' prefix
	-l	Show only names of files that match
	-L	Show only names of files that don't match
	-c	Show only count of matching lines
	-o	Show only the matching part of line
	-q	Quiet. Return 0 if PATTERN is found, 1 otherwise
	-v	Select non-matching lines
	-s	Suppress open and read errors
	-r	Recurse
	-i	Ignore case
	-w	Match whole words only
	-x	Match whole lines only
	-F	PATTERN is a literal (not regexp)
	-E	PATTERN is an extended regexp
	-m N	Match up to N times per file
	-A N	Print N lines of trailing context
	-B N	Print N lines of leading context
	-C N	Same as '-A N -B N'
	-e PTRN	Pattern to match
	-f FILE	Read pattern from file
```

**What was done to fix it?**
The **R option** seems to be not available in **ubuntu-latest**.
Changing it to -r, to make it work.
