### PR TITLE
Support for writing multiple values in one shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,24 @@ This is a GitHub action to write to java `.properties` files.
 
 ### `property`
 
-**Required** The property you want to write.
+**Required** The property or properties you want to write.
 
 ### `value`
 
-**Required** The value of the given property.
+**Required** The value of the given property or properties, in the same order.
 
 ## Example usage
 
     - name: Write value to Properties-file
-      uses: christian-draeger/write-properties@1.0.1
+      uses: christian-draeger/write-properties@1.0.2
       with:
         path: './src/main/resources/application.properties'
-        property: 'the.key.of.the.property'
-        value: 'some value'
+        property: |
+          'the.key.of.the.first.property'
+          'the.key.of.the.second.property'
+        value: |
+          'first value'
+          'second value'
 
 # License
 The scripts and documentation in this project are released under the [MIT License](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Write Properties
-description: Write property to java properties files.
+description: Write properties to a properties file.
 author: Christian Dräger
 branding:
   icon: 'edit'
@@ -9,10 +9,10 @@ inputs:
     description: 'The path to the properties file.'
     required: true
   property:
-    description: 'The property you want to write'
+    description: 'The property keys you want to write. Accepts an array.'
     required: true
   value:
-    description: 'The properties value you want to write'
+    description: 'The property values you want to write (same order as the keys). Accepts an array.'
     required: true
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,23 +15,19 @@ set -euo pipefail
 main() {
 
   local path="$1";
-  local propertyKey="$2";
-  local propertyValue="$3";
+  local keysString="$2";
+  local valuesString="$3";
 
-  echo "path: $path"
-  echo "propertyKey: $propertyKey"
-  echo "propertyValue: $propertyValue"
+  IFS=$'\n\r' read -r -a keys <<<"$keysString"
+  IFS=$'\n\r' read -r -a values <<<"$valuesString"
+  unset IFS
 
-  if ! grep -r "^[#]*\s*${propertyKey}=.*" "$path" > /dev/null; then
-    echo "APPENDING because '${propertyKey}' not found"
-    cat >> "$path" <<EOF
-
-${propertyKey}=${propertyValue}
-EOF
-  else
-    echo "SETTING because '${propertyKey}' found already"
-    sed -ir "s/^[#]*\s*${propertyKey}=.*/$propertyKey=$propertyValue/" "$path"
-  fi
+  local index=0;
+  for i in "${keys[@]}"; do
+    echo "$i=${values[index]}"
+    echo "$i=${values[index]}" >> $path
+    index=$index+1
+  done
 }
 
 main "$1" "$2" "$3"


### PR DESCRIPTION
Fixes #2 

Accepting a newline separated list of keys and values and then matching them up to write them out.

# Notes

This change is completely untested via GitHub Actions itself. I wrote and tested the change locally by running the shell script with newline separated arguments.

I've also removed the check for whether the properties already exist, and just append the lines to the file regardless. Not sure if that's a big problem or not. If it is, I could take a look at adding it back in. I couldn't think of a use-case myself, but I don't know how others may be using this action.

Feel free to reject this if it's problematic, just thought I'd take a shot at it. :)